### PR TITLE
Make assignedTopics an instance field in BigtableSinkTask

### DIFF
--- a/src/main/java/com/sanjuthomas/gcp/bigtable/sink/BigtableSinkTask.java
+++ b/src/main/java/com/sanjuthomas/gcp/bigtable/sink/BigtableSinkTask.java
@@ -49,7 +49,7 @@ import com.sanjuthomas.gcp.bigtable.writer.BigtableWriter;
 @Slf4j
 public class BigtableSinkTask extends SinkTask {
 
-  private static final Set<String> assignedTopics = new LinkedHashSet<>();
+  private final Set<String> assignedTopics = new LinkedHashSet<>();
   private ConfigProvider configProvider;
   @VisibleForTesting
   WriterProvider writerProvider;


### PR DESCRIPTION
## Summary
- Change `assignedTopics` from `static` to an instance field so each sink task tracks its own assigned topics.
- Prevents topic assignments from being shared incorrectly across multiple task instances in the same JVM.

## Test plan
- [x] `mvn test -Dtest=BigtableSinkTaskTest -DexcludeTag=integration` passes on Java 11
- [ ] CI build passes on GitHub Actions


Made with [Cursor](https://cursor.com)